### PR TITLE
Put default None for objectMetadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Example using IO for effects (any monad `F <: Effect` can be used):
 ```scala
 Stream("test data")
   .flatMap(_.getBytes)
-  .uploadS3FileMultipart[IO]("testBucket", "testFile", 25)
+  .uploadS3FileMultipart[IO]("testBucket", "testFile")
 ```
 
 ## Kinesis

--- a/fs2-aws/src/main/scala/fs2/aws/s3/s3.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/s3/s3.scala
@@ -45,7 +45,7 @@ package object s3 {
   def uploadS3FileMultipart[F[_]](
       bucket: String,
       key: String,
-      objectMetadata: Option[ObjectMetadata],
+      objectMetadata: Option[ObjectMetadata] = None,
       s3Client: S3Client[F] = new S3Client[F] {})(implicit F: Effect[F]): fs2.Sink[F, Byte] = {
     def uploadPart(uploadId: String): fs2.Pipe[F, (Chunk[Byte], Long), PartETag] =
       _.flatMap({


### PR DESCRIPTION
Put a default value for objectMetadata in s3. uploadS3FileMultipart and Fixed ReadMe