### PR TITLE
Fixed a bug. Setting partSize

### DIFF
--- a/fs2-aws/src/main/scala/fs2/aws/s3/s3.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/s3/s3.scala
@@ -58,6 +58,7 @@ package object s3 {
                   .withKey(key)
                   .withUploadId(uploadId)
                   .withPartNumber(i.toInt)
+                  .withPartSize(c.size)
                   .withInputStream(new ByteArrayInputStream(c.toArray)))
               .flatMap(r => F.delay(r.getPartETag)))
       })


### PR DESCRIPTION
Setting partSize is needed for the API. Otherwise, it saves an empty file