### PR TITLE
Bump fs2 from 1.0.2 to 1.0.5 

### DIFF
--- a/fs2-aws/build.sbt
+++ b/fs2-aws/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.12.7"
 
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
 
-val fs2Version    = "1.0.2"
+val fs2Version    = "1.0.5"
 val AwsSdkVersion = "1.11.456"
 val cirisVersion  = "0.11.0"
 

--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/consumer.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/consumer.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import cats.effect.{ConcurrentEffect, IO, Timer}
 import cats.implicits._
-import fs2.{Chunk, Pipe, RaiseThrowable, Sink, Stream}
+import fs2.{Chunk, Pipe, RaiseThrowable, Stream}
 import fs2.aws.internal._
 import fs2.aws.internal.Exceptions.KinesisCheckpointException
 import fs2.concurrent.Queue
@@ -210,7 +210,7 @@ object consumer {
     */
   def checkpointRecords_[F[_]](
       checkpointSettings: KinesisCheckpointSettings = KinesisCheckpointSettings.defaultInstance
-  )(implicit F: ConcurrentEffect[F], timer: Timer[F]): Sink[F, CommittableRecord] = {
+  )(implicit F: ConcurrentEffect[F], timer: Timer[F]): Pipe[F, CommittableRecord, Unit] = {
     _.through(checkpointRecords(checkpointSettings))
       .map(_ => ())
   }

--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/publisher.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/publisher.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 
 import cats.Monad
 import cats.effect.{Concurrent, Effect}
-import fs2.{Stream, Pipe, Sink}
+import fs2.{Stream, Pipe}
 import fs2.aws.internal._
 import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture}
 import com.amazonaws.services.kinesis.producer.UserRecordResult
@@ -101,7 +101,7 @@ object publisher {
       producer: KinesisProducerClient[F] = new KinesisProducerClientImpl[F]
   )(implicit F: Effect[F],
     ec: ExecutionContext,
-    concurrent: Concurrent[F]): Sink[F, (String, ByteBuffer)] = {
+    concurrent: Concurrent[F]): Pipe[F, (String, ByteBuffer), Unit] = {
     _.through(writeToKinesis(streamName, parallelism, producer))
       .map(_ => ())
   }

--- a/fs2-aws/src/test/scala/fs2/aws/KinesisProducerSpec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/KinesisProducerSpec.scala
@@ -53,7 +53,8 @@ class KinesisProducerSpec extends FlatSpec with Matchers with BeforeAndAfterEach
     fs2.Stream
       .eval(IO.pure("someData"))
       .flatMap(i => fs2.Stream.emit(("partitionKey", ByteBuffer.wrap(i.getBytes))))
-      .to(writeToKinesis_[IO]("test-stream", producer = TestKinesisProducerClient[IO](result, ops)))
+      .through(
+        writeToKinesis_[IO]("test-stream", producer = TestKinesisProducerClient[IO](result, ops)))
       .compile
       .toVector
       .unsafeRunSync
@@ -103,9 +104,10 @@ class KinesisProducerSpec extends FlatSpec with Matchers with BeforeAndAfterEach
       fs2.Stream
         .eval(IO.pure("someData"))
         .flatMap(i => fs2.Stream.emit(("partitionKey", ByteBuffer.wrap(i.toString.getBytes))))
-        .to(writeToKinesis_[IO]("test-stream", producer = TestKinesisProducerClient[IO](result, IO {
-          throw new Exception("couldn't connect to kinesis")
-        })))
+        .through(
+          writeToKinesis_[IO]("test-stream", producer = TestKinesisProducerClient[IO](result, IO {
+            throw new Exception("couldn't connect to kinesis")
+          })))
         .compile
         .toVector
         .unsafeRunSync


### PR DESCRIPTION
Sink is now deprecated and is replaced with `Pipe[A, B, Unit]`